### PR TITLE
fix ShadowedName before and after

### DIFF
--- a/src/Data/Tree/Zipper.purs
+++ b/src/Data/Tree/Zipper.purs
@@ -122,11 +122,11 @@ siblingAt i l@(Loc r) =
       case (children p) !! i of
         Nothing -> Nothing
         Just c -> 
-          let before = reverse $ take i (children p)
-              after = drop (i+1) (children p)
+          let before' = reverse $ take i (children p)
+              after' = drop (i+1) (children p)
           in Just $ Loc { node: c
-                        , before: before 
-                        , after: after
+                        , before: before'
+                        , after: after'
                         , parents: r.parents
                         }
 


### PR DESCRIPTION
I'm getting this on compile:

```
[1/2 ShadowedName] 

  Name before was shadowed.
  
  in value declaration siblingAt

[2/2 ShadowedName] 

  Name after was shadowed.
  
  in value declaration siblingAt
```