### PR TITLE
fixed a bug I reported in issue #4 also upgraded to PureScript 0.12

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,13 +12,13 @@
     "url": "git://github.com/dmbfm/purescript-tree.git"
   },
   "dependencies": {
-    "purescript-prelude": "^3.1.0",
-    "purescript-console": "^3.0.0",
-    "purescript-lists": "^4.9.1",
-    "purescript-free": "^4.1.0"
+    "purescript-prelude": "^4.0.1",
+    "purescript-console": "^4.1.0",
+    "purescript-lists": "^5.0.0",
+    "purescript-free": "^5.1.0"
   },
   "devDependencies": {
-    "purescript-psci-support": "^3.0.0",
-    "purescript-spec": "^1.0.0"
+    "purescript-psci-support": "^4.0.0",
+    "purescript-spec": "^3.0.0"
   }
 }

--- a/src/Data/Tree.purs
+++ b/src/Data/Tree.purs
@@ -21,7 +21,7 @@ mkTree = mkCofree
 drawTree :: Tree String -> String
 drawTree t = tailRec go {level: 0, drawn: (head t) <> "\n", current: (tail t)}
   where
-    go :: _ -> Step _ String
+    go :: { current :: List (Tree String) , drawn :: String , level :: Int } -> Step { current :: List (Tree String) , drawn :: String , level :: Int } String
     go {level: l, drawn: s, current: Nil} = Done s
     go {level: l, drawn: s, current: c:cs } = 
       let drawn = (power "       " l) <> "|----> " <> (head c) <> "\n" in
@@ -39,7 +39,7 @@ scanTree f b n =
   let fb = f (head n) b 
   in fb :< (tailRec go {b: fb, current: (tail n), final: Nil})
   where
-    go :: _ -> Step _ (Forest b)
+    go :: { final :: List (Cofree List b) , current :: List (Cofree List a) , b :: b } -> Step { final :: List (Cofree List b) , current :: List (Cofree List a) , b :: b } (Forest b)
     go {b: b', current: Nil, final: final} = Done final
     go {b: b', current: c:cs, final: final} = 
       let fb' = f (head c) b' 
@@ -52,7 +52,7 @@ scanTreeAccum f b n =
   let fb = f (head n) b 
   in fb.value :< (tailRec go {b: fb.accum , current: (tail n), final: Nil})
   where
-    go :: _ -> Step _ (Forest c)
+    go :: { final :: List (Cofree List c) , current :: List (Cofree List a) , b :: b } -> Step { final :: List (Cofree List c) , current :: List (Cofree List a) , b :: b } (Forest c)
     go {b: b', current: Nil, final: final} = Done final
     go {b: b', current: c:cs, final: final} = 
       let fb' = f (head c) b' 

--- a/src/Data/Tree.purs
+++ b/src/Data/Tree.purs
@@ -21,7 +21,7 @@ mkTree = mkCofree
 drawTree :: Tree String -> String
 drawTree t = tailRec go {level: 0, drawn: (head t) <> "\n", current: (tail t)}
   where
-    go :: { current :: List (Tree String) , drawn :: String , level :: Int } -> Step { current :: List (Tree String) , drawn :: String , level :: Int } String
+    go :: { current :: Forest String , drawn :: String , level :: Int } -> Step { current :: Forest String , drawn :: String , level :: Int } String
     go {level: l, drawn: s, current: Nil} = Done s
     go {level: l, drawn: s, current: c:cs } = 
       let drawn = (power "       " l) <> "|----> " <> (head c) <> "\n" in
@@ -39,7 +39,7 @@ scanTree f b n =
   let fb = f (head n) b 
   in fb :< (tailRec go {b: fb, current: (tail n), final: Nil})
   where
-    go :: { final :: List (Cofree List b) , current :: List (Cofree List a) , b :: b } -> Step { final :: List (Cofree List b) , current :: List (Cofree List a) , b :: b } (Forest b)
+    go :: { final :: Forest b , current :: Forest a , b :: b } -> Step { final :: Forest b , current :: Forest a , b :: b } (Forest b)
     go {b: b', current: Nil, final: final} = Done final
     go {b: b', current: c:cs, final: final} = 
       let fb' = f (head c) b' 
@@ -52,7 +52,7 @@ scanTreeAccum f b n =
   let fb = f (head n) b 
   in fb.value :< (tailRec go {b: fb.accum , current: (tail n), final: Nil})
   where
-    go :: { final :: List (Cofree List c) , current :: List (Cofree List a) , b :: b } -> Step { final :: List (Cofree List c) , current :: List (Cofree List a) , b :: b } (Forest c)
+    go :: { final :: Forest c , current :: Forest a , b :: b } -> Step { final :: Forest c , current :: Forest a , b :: b } (Forest c)
     go {b: b', current: Nil, final: final} = Done final
     go {b: b', current: c:cs, final: final} = 
       let fb' = f (head c) b' 

--- a/src/Data/Tree/Zipper.purs
+++ b/src/Data/Tree/Zipper.purs
@@ -264,21 +264,24 @@ findFromRootWhere predicate loc = findDownWhere predicate $ root loc
 findFromRoot :: forall a. Eq a => a -> Loc a -> Maybe (Loc a)
 findFromRoot a = findFromRootWhere (_ == a)
 
+-- | flattens the Tree into a List depth first.
 flattenLocDepthFirst :: ∀ a. Loc a -> List (Loc a)
 flattenLocDepthFirst loc = loc : (go loc)
-  where 
+  where
     go :: Loc a -> List (Loc a)
-    go goLoc = 
-      let 
-        downs = goDir goLoc down 
-        nexts = goDir goLoc next
-      in 
+    go loc' =
+      let
+        downs = goDir loc' down
+        nexts = goDir loc' next
+      in
         downs <> nexts
 
     goDir :: Loc a -> (Loc a -> Maybe (Loc a)) -> List (Loc a)
-    goDir loc' dirFn = case (dirFn loc') of 
-      Just justLoc' -> loc' : go justLoc'
-      Nothing   -> Nil
+    goDir loc' dirFn = case (dirFn loc') of
+      Just l  -> l : go l
+      Nothing -> Nil
+
+                                                            
 
 -- Setters and Getters
 node :: forall a. Loc a -> Tree a 

--- a/src/Data/Tree/Zipper.purs
+++ b/src/Data/Tree/Zipper.purs
@@ -264,6 +264,22 @@ findFromRootWhere predicate loc = findDownWhere predicate $ root loc
 findFromRoot :: forall a. Eq a => a -> Loc a -> Maybe (Loc a)
 findFromRoot a = findFromRootWhere (_ == a)
 
+flattenLocDepthFirst :: ∀ a. Loc a -> List (Loc a)
+flattenLocDepthFirst loc = loc : (go loc)
+  where 
+    go :: Loc a -> List (Loc a)
+    go goLoc = 
+      let 
+        downs = goDir goLoc down 
+        nexts = goDir goLoc next
+      in 
+        downs <> nexts
+
+    goDir :: Loc a -> (Loc a -> Maybe (Loc a)) -> List (Loc a)
+    goDir loc' dirFn = case (dirFn loc') of 
+      Just justLoc' -> loc' : go justLoc'
+      Nothing   -> Nil
+
 -- Setters and Getters
 node :: forall a. Loc a -> Tree a 
 node (Loc r) = r.node

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,10 +4,12 @@ import Prelude
 
 import Control.Comonad.Cofree (head, (:<))
 import Control.Monad.Eff (Eff)
+import Control.Monad.Aff.Console (log)
 import Data.List (List(Nil), (:))
 import Data.Maybe (Maybe(..), fromJust)
-import Data.Tree (Tree, mkTree, scanTree)
-import Data.Tree.Zipper (down, findDownWhere, findFromRoot, findUp, fromTree, insertAfter, modifyValue, next, toTree, value)
+import Data.Tree (Tree, mkTree, scanTree, showTree)
+import Data.Tree.Zipper (down, findDownWhere, findFromRoot, findUp, flattenLocDepthFirst, fromTree, insertAfter, modifyValue, next, toTree, value)
+import Debug.Trace (spy)
 import Partial.Unsafe (unsafePartial)
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
@@ -254,6 +256,12 @@ main = run [consoleReporter] do
     it "Should find 8 from the sampleTree (the bottom) and then find 7 using findFromRoot" do
       let eight = unsafePartial $ fromJust $ findDownWhere (_ == 8) $ fromTree sampleTree
       shouldEqual (Just 7) (findFromRoot 7 eight <#> value)
+
+    it "Should flatten the Tree into a list of locations following a depth first pattern" do
+      let flat = map value $ flattenLocDepthFirst $ fromTree sampleTree
+      -- log $ showTree sampleTree
+      -- log $ show flat
+      shouldEqual flat (1 : 2 : 3 : 4 : 5 : 6 : 7 : 8 : Nil)
 
 
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,14 +2,12 @@ module Test.Main where
 
 import Prelude
 
-import Control.Comonad.Cofree (Cofree, head, (:<))
+import Control.Comonad.Cofree (head, (:<))
 import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Class (liftEff)
-import Control.Monad.Eff.Console (CONSOLE, log)
-import Data.List (List(..), (:))
-import Data.Maybe (fromJust)
-import Data.Tree (Tree, mkTree, scanTree, showTree)
-import Data.Tree.Zipper (down, fromTree, insertAfter, modifyValue, next, toTree)
+import Data.List (List(Nil), (:))
+import Data.Maybe (Maybe(..), fromJust)
+import Data.Tree (Tree, mkTree, scanTree)
+import Data.Tree.Zipper (down, findDownWhere, findFromRoot, findUp, fromTree, insertAfter, modifyValue, next, toTree, value)
 import Partial.Unsafe (unsafePartial)
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
@@ -140,3 +138,122 @@ main = run [consoleReporter] do
                 : Nil
       shouldEqual (eq root' result) true
       shouldEqual (eq root'' result') true
+
+    it "Should findDownWhere with single node" do
+      let tree = 1 :< Nil
+      let loc = fromTree tree
+      shouldEqual (Just 1) ((findDownWhere (_ == 1) loc) <#> value)
+
+    it "Should findDownWhere with 2 nodes and 2 levels" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 2) ((findDownWhere (_ == 2) loc) <#> value)
+
+    it "Should findDownWhere with 3 nodes and 2 levels" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                    : (3 :< Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 3) ((findDownWhere (_ == 3) loc) <#> value)
+
+    it "Should findDownWhere with 4 nodes and 2 levels" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                    : (3 :< Nil) 
+                    : (4 :< Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 4) ((findDownWhere (_ == 4) loc) <#> value)
+
+    it "Should findDownWhere with 5 nodes and 3 levels" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                    : (3 :< Nil) 
+                    : (4 :< 
+                          (5 :< Nil)
+                        : Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 5) ((findDownWhere (_ == 5) loc) <#> value)
+
+    it "Should findDownWhere with 6 nodes and 3 levels" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                    : (3 :< Nil) 
+                    : (4 :< 
+                          (5 :< Nil)
+                        : (6 :< Nil)
+                        : Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 6) ((findDownWhere (_ == 6) loc) <#> value)
+
+    it "Should findDownWhere with 7 nodes and 4 levels" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                    : (3 :< Nil) 
+                    : (4 :< 
+                          (5 :< Nil)
+                        : (6 :< 
+                              (7 :< Nil) : Nil)
+                        : Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 7) ((findDownWhere (_ == 7) loc) <#> value)
+
+    it "Should findDownWhere with 8 nodes and 4 levels" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                    : (3 :< Nil) 
+                    : (4 :< 
+                          (5 :< Nil)
+                        : (6 :< 
+                              (7 :< Nil) : Nil)
+                        : (8 :< Nil)
+                        : Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 8) ((findDownWhere (_ == 8) loc) <#> value)
+
+    it "Should findDownWhere with 8 nodes and 4 levels with a step back" do
+      let tree = 1 :< 
+                      (2 :< Nil) 
+                    : (3 :< Nil) 
+                    : (4 :< 
+                          (5 :< Nil)
+                        : (6 :< 
+                              (7 :< Nil) : Nil)
+                        : (8 :< Nil)
+                        : Nil) 
+                      : Nil
+      -- log $ showTree tree
+      let loc = fromTree tree
+      shouldEqual (Just 7) ((findDownWhere (_ == 7) loc) <#> value)
+
+    it "Should find 7 from the sampleTree" do
+      shouldEqual (Just 7) (findDownWhere (_ == 7) (fromTree sampleTree) <#> value)
+
+    it "Should find 8 from the sampleTree (the bottom) and then find 1 (the top) with findUp" do
+      let eight = unsafePartial $ fromJust $ findDownWhere (_ == 8) $ fromTree sampleTree
+      shouldEqual (Just 1) (findUp 1 eight <#> value)
+
+    it "Should find 8 from the sampleTree (the bottom) but then not find 7 because it would require a downward traversal" do
+      let eight = unsafePartial $ fromJust $ findDownWhere (_ == 8) $ fromTree sampleTree
+      shouldEqual Nothing (findUp 7 eight <#> value)
+
+    it "Should find 8 from the sampleTree (the bottom) and then find 7 using findFromRoot" do
+      let eight = unsafePartial $ fromJust $ findDownWhere (_ == 8) $ fromTree sampleTree
+      shouldEqual (Just 7) (findFromRoot 7 eight <#> value)
+
+
+

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -3,18 +3,16 @@ module Test.Main where
 import Prelude
 
 import Control.Comonad.Cofree (head, (:<))
-import Control.Monad.Eff (Eff)
-import Control.Monad.Aff.Console (log)
 import Data.List (List(Nil), (:))
 import Data.Maybe (Maybe(..), fromJust)
-import Data.Tree (Tree, mkTree, scanTree, showTree)
+import Data.Tree (Tree, mkTree, scanTree)
 import Data.Tree.Zipper (down, findDownWhere, findFromRoot, findUp, flattenLocDepthFirst, fromTree, insertAfter, modifyValue, next, toTree, value)
-import Debug.Trace (spy)
+import Effect (Effect)
 import Partial.Unsafe (unsafePartial)
 import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter (consoleReporter)
-import Test.Spec.Runner (RunnerEffects, run)
+import Test.Spec.Runner (run)
 
 sampleTree :: Tree Int
 sampleTree = 
@@ -30,7 +28,7 @@ sampleTree =
       )
     : Nil
 
-main :: forall e. Eff (RunnerEffects e) Unit
+main :: Effect Unit
 main = run [consoleReporter] do 
   describe "Tree" do    
 
@@ -259,8 +257,8 @@ main = run [consoleReporter] do
 
     it "Should flatten the Tree into a list of locations following a depth first pattern" do
       let flat = map value $ flattenLocDepthFirst $ fromTree sampleTree
-      -- log $ showTree sampleTree
-      -- log $ show flat
+      --log $ showTree sampleTree
+      --log $ show flat
       shouldEqual flat (1 : 2 : 3 : 4 : 5 : 6 : 7 : 8 : Nil)
 
 


### PR DESCRIPTION
Hey, I really enjoy using this library, and I found a bug, needed it fixed, and thought I could add a couple of functions that others might want too:

The bug was where `findFromRoot` would not find some nodes because `findDown` was not exhaustively searching siblings. To fix this I created a couple of new functions called `findDownWhere` and `findUpWhere` that will exhaustively search in their respective ways and they differ from `findDown` and `findUp` by taking a predicate (something I needed and thought would be helpful for others). This fixed the original issue `findFromRoot` had. I also rewrote `findUp` and `findDown` in terms of their predicate-taking counterparts. I also added several tests to check my work. 